### PR TITLE
Add a "Deploy to Azure" button in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # WebAppWithFSharpLibrary
 Test MVC4 app with dependency on F# library
 
-try a deployment:
 [![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# WebAppWithFSharpLibrary
+Test MVC4 app with dependency on F# library
+
+try a deployment:
+[![Deploy to Azure](http://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/)


### PR DESCRIPTION
Hi,
I was interested to try azuredeploy.net with a project involving F#, and was able to successfully deploy this project with a simple button push.  The button seems like a good addition to the project template.
